### PR TITLE
Enhancements to auto-generated repo links

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,6 @@
   </div>
   <div class='hidden' id='main-div'>
     <button id="TheButton"><p class="rainbow">Click Me</p></button>
-
     <p id="label">Loading... (If this doesn't disappear in a few seconds, reload the page)</p>
     <p id="user-time"></p>
 
@@ -60,9 +59,6 @@
     </table>
   </div>
   <br />
-  <!-- repo links generated automatically -->
-  <p id="repolink"></p>
-  <p id="livelink"></p>
   <!-- ripped shamelessly from the MDN -->
   <script type="text/javascript">
     var windowObjectReference = null; // global variable
@@ -87,9 +83,15 @@
     }
 
   </script>
+  <div id="footer">
+    <!-- repo links generated automatically -->
+    <p id="repolink"></p>
+    <p id="livelink"></p>
+    <p id="about"><a href="/TheButton/about/" target="aboutPage" onclick="openAbout(); return false;">About</a></p>
+    <input type="button" value="Log Out" id="logoutbutton" class="hidden">
+  </div>
+  <br />
 
-  <p id="about"><a href="/TheButton/about/" target="aboutPage" onclick="openAbout(); return false;">About</a></p>
-  <input type="button" value="Log Out" id="logoutbutton">
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
   <br />
   <!-- repo links generated automatically -->
   <p id="repolink"></p>
+  <p id="livelink"></p>
   <!-- ripped shamelessly from the MDN -->
   <script type="text/javascript">
     var windowObjectReference = null; // global variable

--- a/js/main.js
+++ b/js/main.js
@@ -201,12 +201,35 @@ if (location.href.endsWith("?logout")) {
   work.
 */
 var linkOverride;
+/*
+  add strings to otherRepos (in “username/repo-name” format) as
+  desired to produce additional links for forks
+*/
+var otherRepos = [];
 window.onload = e => {
   var i = location.hostname.split("").reverse().join("").substring(10).split("").reverse().join(""),
-    t = "GitHub Repo: "
-  t += "legend-of-iphoenix" != i ? '<a href="https://github.com/' + i + location.pathname + '">This fork</a> | <a href="https://github.com/Legend-of-iPhoenix/TheButton">Original by _iPhoenix_</a>' : '<a href="https://github.com/Legend-of-iPhoenix/TheButton">Here</a>', 
-  t = linkOverride ? 'GitHub Repo: <a href="'+linkOverride+'">This Fork</a> | <a href="https://github.com/Legend-of-iPhoenix/TheButton">Original by _iPhoenix_</a>':t;
-  document.getElementById("repolink").innerHTML = t
+  this_repo_url = (linkOverride ? linkOverride : 'https://github.com/' + i + '/' + location.pathname.split('/')[1]);
+  is_original = i == 'legend-of-iphoenix';
+  tr = 'GitHub repo: <a href="' + this_repo_url + '">' + (is_original ? 'Here' : i + ' (this fork)') + '</a>';
+  if (!is_original) tr += ' | <a href="https://github.com/Legend-of-iPhoenix/TheButton">_iPhoenix_ (original)</a>';
+
+  tl = '';
+  if ('legend-of-iphoenix' != i) {
+    tl += '<b>' + i + '</b> | <a href="https://legend-of-iphoenix.github.io/TheButton/">iPhoenix</a>';
+  }
+  for (i=0; i<otherRepos.length; i++) {
+    repo = otherRepos[i].split('/');
+    tr += ' | <a href="https://github.com/' + repo[0] + '/' + repo[1] + '">' + repo[0] + '</a>';
+    tl += (tl ? ' | ' : '') + '<a href="https://' + repo[0] + '.github.io/' + repo[1] + '">' + repo[0] + '</a>';
+  }
+  if (tl) tl = 'Live site: ' + tl;
+
+  document.getElementById("repolink").innerHTML = tr;
+  if (tl) {
+    document.getElementById("livelink").innerHTML = tl;
+  } else {
+    document.getElementById("livelink").remove();
+  }
   document.getElementById("logoutbutton").onclick = function() {
     firebase.auth().signOut();
     location.reload();

--- a/js/main.js
+++ b/js/main.js
@@ -211,11 +211,11 @@ window.onload = e => {
   this_repo_url = (linkOverride ? linkOverride : 'https://github.com/' + i + '/' + location.pathname.split('/')[1]);
   is_original = i == 'legend-of-iphoenix';
   tr = 'GitHub repo: <a href="' + this_repo_url + '">' + (is_original ? 'Here' : i + ' (this fork)') + '</a>';
-  if (!is_original) tr += ' | <a href="https://github.com/Legend-of-iPhoenix/TheButton">_iPhoenix_ (original)</a>';
+  if (!is_original) tr += ' | <a href="https://github.com/Legend-of-iPhoenix/TheButton">Legend-of-iPhoenix (original)</a>';
 
   tl = '';
   if (!is_original) {
-    tl += '<b>' + i + '</b> | <a href="https://legend-of-iphoenix.github.io/TheButton/">iPhoenix</a>';
+    tl += '<b>' + i + '</b> | <a href="https://legend-of-iphoenix.github.io/TheButton/">Legend-of-iPhoenix</a>';
   } else if (otherRepos.length) {
     tl += '<b>' + i + '</b>';
   }

--- a/js/main.js
+++ b/js/main.js
@@ -214,8 +214,10 @@ window.onload = e => {
   if (!is_original) tr += ' | <a href="https://github.com/Legend-of-iPhoenix/TheButton">_iPhoenix_ (original)</a>';
 
   tl = '';
-  if ('legend-of-iphoenix' != i) {
+  if (!is_original) {
     tl += '<b>' + i + '</b> | <a href="https://legend-of-iphoenix.github.io/TheButton/">iPhoenix</a>';
+  } else if (otherRepos.length) {
+    tl += '<b>' + i + '</b>';
   }
   for (i=0; i<otherRepos.length; i++) {
     repo = otherRepos[i].split('/');


### PR DESCRIPTION
I propose these changes to the auto-generated repo links:

* For forks, this generates links to the live-demo sites of those forks as well as to the GitHub repo itself
* For more convenient collaboration, extra links to other forks can be created by adding entries to otherRepos (for instance, I have mine set to ["jcgter777/TheButton", "Michael2-3B/TheButton"])

With the otherRepos variable set to an empty list, the output for the iPhoenix repo should be the same as before, only producing a single “here” link pointing to this repo.